### PR TITLE
fix storage quoting with long long values

### DIFF
--- a/src/storage/mysql/mysql_storage.h
+++ b/src/storage/mysql/mysql_storage.h
@@ -55,6 +55,7 @@ private:
     virtual inline zmm::String quote(unsigned long val) { return zmm::String::from(val); }
     virtual inline zmm::String quote(bool val) { return zmm::String(val ? '1' : '0'); }
     virtual inline zmm::String quote(char val) { return quote(zmm::String(val)); }
+    virtual inline zmm::String quote(long long val) { return zmm::String::from(val); }
     virtual zmm::Ref<SQLResult> select(const char *query, int length);
     virtual int exec(const char *query, int length, bool getLastInsertId = false);
     virtual void storeInternalSetting(zmm::String key, zmm::String value);

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -81,6 +81,7 @@ public:
     virtual zmm::String quote(unsigned long val) = 0;
     virtual zmm::String quote(bool val) = 0;
     virtual zmm::String quote(char val) = 0;
+    virtual zmm::String quote(long long val) = 0;
     virtual zmm::Ref<SQLResult> select(const char *query, int length) = 0;
     virtual int exec(const char *query, int length, bool getLastInsertId = false) = 0;
     

--- a/src/storage/sqlite3/sqlite3_storage.h
+++ b/src/storage/sqlite3/sqlite3_storage.h
@@ -160,6 +160,7 @@ private:
     virtual inline zmm::String quote(unsigned long val) { return zmm::String::from(val); }
     virtual inline zmm::String quote(bool val) { return zmm::String(val ? '1' : '0'); }
     virtual inline zmm::String quote(char val) { return quote(zmm::String(val)); }
+    virtual inline zmm::String quote(long long val) { return zmm::String::from(val); }
     virtual zmm::Ref<SQLResult> select(const char *query, int length);
     virtual int exec(const char *query, int length, bool getLastInsertId = false);
     virtual void storeInternalSetting(zmm::String key, zmm::String value);


### PR DESCRIPTION
On 32-bit systems w/64-bit time_t's (like the x32 ABI) we fail to build:
../src/storage/sql_storage.cc: In member function 'virtual void SQLStorage::autoscanUpdateLM(zmm::Ref<AutoscanDirectory>)':
../src/storage/sql_storage.cc:2139:81: error: call of overloaded 'quote(time_t)' is ambiguous
         << " SET " << TQ("last_modified") << '=' << quote(adir->getPreviousLMT())

Handle long long types explicitly to fix that.