### PR TITLE
Changes for Cover Art [folder, track] support, Solaris support too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ config.status
 build/mediatomb
 .idea
 cmake-build-debug
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+mediatomb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,36 @@ add_executable(mediatomb src/main.cc $<TARGET_OBJECTS:libmediatomb>)
 target_include_directories(mediatomb PRIVATE "${CMAKE_SOURCE_DIR}/src")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_FLAGS "-Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+
+
+# Host OS Check
+set(HOST_OS "")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(HOST_OS "linux")
+endif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES ".*(SunOS|Solaris).*")
+    set(HOST_OS "solaris")
+    set(SOLARIS 1)
+endif(${CMAKE_SYSTEM_NAME} MATCHES ".*(SunOS|Solaris).*")
+if(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD.*")
+    set(HOST_OS "BSD")
+    set(BSD 1)
+endif(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD.*")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set(HOST_OS "darwin")
+endif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+if(NOT HOST_OS)
+    message(FATAL_ERROR 
+                "mediatomb was unable to deterimine the host OS. Please report this. Value of CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+endif(NOT HOST_OS)
+
+
+if (SOLARIS)
+    add_definitions(-DSOLARIS)
+    # we need these specially called out as not in packages [OmniOS/joyent]
+    target_link_libraries (mediatomb "-luuid -lsocket -lnsl -liconv")
+endif(SOLARIS)
 
 add_definitions(-DPACKAGE_NAME="MediaTomb-v00d00")
 add_definitions(-DVERSION="0.13.0_alpha-v00d00")
@@ -306,15 +335,18 @@ add_definitions(-DEXTERNAL_TRANSCODING)
 
 # This only compiles them in
 add_definitions(-DDEBUG_LOG_ENABLED)
-add_definitions(-DTOMBDEBUG)
+#add_definitions(-DTOMBDEBUG)           # this defaults to extra-verbose, and swaps sense of -D
 add_definitions(-DLOG_ENABLED)
 
 find_package(Threads REQUIRED)
 target_link_libraries (mediatomb ${CMAKE_THREAD_LIBS_INIT})
 
-find_package(INotify REQUIRED)
-target_link_libraries (mediatomb ${INOTIFY_LIBRARY})
-add_definitions(-DHAVE_INOTIFY)
+if (NOT SOLARIS)
+    # not supported on solaris
+    find_package(INotify REQUIRED)
+    target_link_libraries (mediatomb ${INOTIFY_LIBRARY})
+    add_definitions(-DHAVE_INOTIFY)
+endif (NOT SOLARIS)
 
 find_package(LibUUID REQUIRED)
 include_directories(${LIBUUID_INCLUDE_DIRS})

--- a/src/storage.h
+++ b/src/storage.h
@@ -165,6 +165,9 @@ public:
     /* utility methods */
     virtual zmm::Ref<CdsObject> loadObject(int objectID) = 0;
     virtual int getChildCount(int contId, bool containers = true, bool items = true, bool hideFsRoot = false) = 0;
+
+    virtual zmm::String findFolderImage(int id, zmm::String trackArtBase) = 0;
+
     
     class ChangedContainers : public Object
     {

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -1297,6 +1297,46 @@ String SQLStorage::incrementUpdateIDs(int *ids, int size)
     return buf->toString(1);
 }
 
+// id is the parent_id for cover media to find, and if set, trackArtBase is the case-folded 
+// name of the track to try as artwork
+String SQLStorage::findFolderImage(int id, String trackArtBase)
+{
+    Ref<StringBuffer> q(new StringBuffer());
+    // folder.jpg or cover.jpg [and variants]
+    // note - "_" is regexp "." and "%" is regexp ".*" in sql LIKE land
+    *q << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    *q << "( ";
+    if (trackArtBase.length()>0) {
+        *q << "lower(" << TQ("dc_title") << ") " << "LIKE" << TQ(trackArtBase + ".jp%") << " OR ";
+    }
+    *q << "lower(" << TQ("dc_title") << ") " << "LIKE" << TQ("cover.jp%") << " OR ";
+    *q << "lower(" << TQ("dc_title") << ") " << "LIKE" << TQ("albumart%.jp%") << " OR ";
+    *q << "lower(" << TQ("dc_title") << ") " << "LIKE" << TQ("album.jp%") << " OR ";
+    *q << "lower(" << TQ("dc_title") << ") " << "LIKE" << TQ("front.jp%") << " OR ";
+    *q << "lower(" << TQ("dc_title") << ") " << "LIKE" << TQ("folder.jp%");
+    *q << " ) AND ";
+    *q << TQ("upnp_class") << '=' << TQ(UPNP_DEFAULT_CLASS_IMAGE_ITEM) << " AND ";
+    *q << TQ("parent_id") << " IN ";
+    *q << "(";
+    *q << "SELECT " << TQ("parent_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    *q << TQ("parent_id") << '=' << TQ(String::from(id)) << " AND ";
+    *q << TQ("object_type") << '=' << TQ(OBJECT_TYPE_ITEM);
+    *q << ")";
+    *q << " ORDER BY " << TQ("dc_title") << " DESC";
+
+    log_debug("findFolderImage %d, %s\n", id, q->c_str());
+    Ref<SQLResult> res = select(q);
+    if (res == nil)
+        throw _Exception(_("db error"));
+    Ref<SQLRow> row;
+    if ((row = res->nextRow()) != nil)  // we only care about the first result
+    {
+        log_debug("findFolderImage result: %s\n", row->col(0).c_str());
+        return row->col(0);
+    }
+    return nil;
+}
+
 /*
 Ref<Array<CdsObject> > SQLStorage::selectObjects(Ref<SelectParam> param)
 {

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -2341,9 +2341,9 @@ void SQLStorage::addToInsertBuffer(Ref<StringBuffer> query)
 {
     assert(doInsertBuffering());
     
+    AUTOLOCK(mutex);
     _addToInsertBuffer(query);
     
-    AUTOLOCK(mutex);
     insertBufferEmpty = false;
     insertBufferStatementCount++;
     insertBufferByteCount += query->length();

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -108,6 +108,8 @@ public:
     
     virtual zmm::Ref<CdsObject> loadObjectByServiceID(zmm::String serviceID);
     virtual zmm::Ref<zmm::IntArray> getServiceObjectIDs(char servicePrefix);
+
+    virtual zmm::String findFolderImage(int id, zmm::String trackArtBase);
     
     /* accounting methods */
     virtual int getTotalFiles();

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -110,6 +110,33 @@ Ref<Element> UpnpXML_DIDLRenderObject(Ref<CdsObject> obj, bool renderActions, in
         
         CdsResourceManager::addResources(item, result);
         
+        if (upnp_class == UPNP_DEFAULT_CLASS_MUSIC_TRACK) {
+            Ref<Storage> storage = Storage::getInstance();
+            // extract extension-less, lowercase track name to search for corresponding
+            // image as cover alternative
+            String dctl = item->getTitle().toLower();
+            String trackArtBase = String();
+            int doti = dctl.rindex('.');
+            if (doti>=0) {
+                trackArtBase = dctl.substring(0, doti);
+            } 
+            String aa_id = storage->findFolderImage(item->getParentID(), trackArtBase);
+            if (aa_id != nil) {
+                String url;
+                Ref<Dictionary> dict(new Dictionary());
+                dict->put(_(URL_OBJECT_ID), aa_id);
+
+                url = Server::getInstance()->getVirtualURL() +
+                        _(_URL_PARAM_SEPARATOR) +
+                        CONTENT_MEDIA_HANDLER + _(_URL_PARAM_SEPARATOR) +
+                        dict->encodeSimple() + _(_URL_PARAM_SEPARATOR) +
+                        _(URL_RESOURCE_ID) + _(_URL_PARAM_SEPARATOR) + "0";
+                log_debug("UpnpXML_DIDLRenderObject: url: %s\n", url.c_str());
+                Ref<Element> aa(new Element(MetadataHandler::getMetaFieldName(M_ALBUMARTURI)));
+                aa->setText(url);
+                result->appendElementChild(aa);
+            }
+        }
         result->setName(_("item"));
     }
     else if (IS_CDS_CONTAINER(objectType))
@@ -140,8 +167,25 @@ Ref<Element> UpnpXML_DIDLRenderObject(Ref<CdsObject> obj, bool renderActions, in
                     result->appendElementChild(UpnpXML_DIDLRenderCreator(el->getValue()));
                 }
             }
+        }
+        if (upnp_class == UPNP_DEFAULT_CLASS_MUSIC_ALBUM || upnp_class == UPNP_DEFAULT_CLASS_CONTAINER) {
+            Ref<Storage> storage = Storage::getInstance();
+            String aa_id = storage->findFolderImage(cont->getID(), String());
+            if (aa_id != nil) {
+                String url;
+                Ref<Dictionary> dict(new Dictionary());
+                dict->put(_(URL_OBJECT_ID), aa_id);
 
-
+                url = Server::getInstance()->getVirtualURL() +
+                    _(_URL_PARAM_SEPARATOR) +
+                    CONTENT_MEDIA_HANDLER + _(_URL_PARAM_SEPARATOR) +
+                    dict->encodeSimple() + _(_URL_PARAM_SEPARATOR) +
+                    _(URL_RESOURCE_ID) + _(_URL_PARAM_SEPARATOR) + "0";
+                log_debug("UpnpXML_DIDLRenderObject: url: %s\n", url.c_str());
+                Ref<Element> aa(new Element(MetadataHandler::getMetaFieldName(M_ALBUMARTURI)));
+                aa->setText(url);
+                result->appendElementChild(aa);
+            }
         }
         
     }


### PR DESCRIPTION
beyond the cover art work we've been discussing in the forum, I added some tweaks to the Cmake configuration
I definitely appreciate the cmake work - a huge improvement!
however it was stomping on cflags [the -Wall] and broke solaris support, both of which I've fixed
also wee tweak to .gitignore FTW

to build under OmniOS with Joyent packages and a locally built libupnp, FWIW, this worked:
env PKG_CONFIG_PATH=/usr/local/lib/pkgconfig cmake CMakeLists.txt  -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS=-m64 -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS=-m64 -DWITH_MAGIC=1 -DWITH_MYSQL=0 -DWITH_CURL=0 -DWITH_JS=0 -DWITH_TAGLIB=1 -DWITH_AVCODEC=0 -DWITH_DVDNAV=0 -DWITH_EXIF=1 -DWITH_LASTFM=0

More tweaks may be needed for JS; once i verify this is running stably, i'll try that...