### PR TITLE
Fix handling of the --debug command line option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(WITH_AVCODEC        0 CACHE BOOL "Enable libav")
 set(WITH_DVDNAV         0 CACHE BOOL "Enable DVD-Nav")
 set(WITH_EXIF           1 CACHE BOOL "Use libexif to extract image metadata")
 set(WITH_LASTFM         0 CACHE BOOL "Enable LastFM")
+set(WITH_LOGGING        1 CACHE BOOL "Enable file logging")
+set(WITH_DEBUG_LOGGING  1 CACHE BOOL "Enables debug logging")
 
 project("MediaTomb")
 
@@ -340,10 +342,12 @@ MESSAGE( STATUS "CMAKE_INSTALL_PREFIX: " ${CMAKE_INSTALL_PREFIX} )
 add_definitions(-DCOMPILE_INFO="")
 add_definitions(-DEXTERNAL_TRANSCODING)
 
-# This only compiles them in
-add_definitions(-DDEBUG_LOG_ENABLED)
-#add_definitions(-DTOMBDEBUG)           # this defaults to extra-verbose, and swaps sense of -D
-add_definitions(-DLOG_ENABLED)
+if (WITH_LOGGING OR WITH_DEBUG_LOGGING)
+    add_definitions(-DLOG_ENABLED)
+endif()
+if (WITH_DEBUG_LOGGING)
+    add_definitions(-DTOMBDEBUG)
+endif()
 
 find_package(Threads REQUIRED)
 target_link_libraries (mediatomb ${CMAKE_THREAD_LIBS_INIT})

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -128,11 +128,7 @@ void _log_js(const char *format, ...)
 void _log_debug(const char *format, const char *file, int line, const char *function, ...)
 {
     bool enabled;
-#ifdef TOMBDEBUG
-    enabled = !ConfigManager::isDebugLogging();
-#else
     enabled = ConfigManager::isDebugLogging();
-#endif
     if (enabled)
     {
         va_list ap;
@@ -151,11 +147,7 @@ void _print_backtrace(FILE* file)
 #if defined HAVE_BACKTRACE && defined HAVE_BACKTRACE_SYMBOLS
 
     bool enabled;
-#ifdef TOMBDEBUG
-    enabled = !ConfigManager::isDebugLogging();
-#else
     enabled = ConfigManager::isDebugLogging();
-#endif
     if (enabled)
     {
         void* b[100];

--- a/src/logger.h
+++ b/src/logger.h
@@ -49,17 +49,12 @@ void log_close();
 #define log_error(format, ...) _log_error(format, ## __VA_ARGS__)
 #define log_js(format, ...) _log_js(format, ## __VA_ARGS__)
 
-#ifdef DEBUG_LOG_ENABLED
-    #define log_debug(format, ...) _log_debug(format, __FILE__, __LINE__, __func__, ## __VA_ARGS__)
-    #define print_backtrace() _print_backtrace()
-#else
 #ifdef TOMBDEBUG
     #define log_debug(format, ...) _log_debug(format, __FILE__, __LINE__, __func__, ## __VA_ARGS__)
     #define print_backtrace() _print_backtrace()
 #else
     #define log_debug(format, ...)
     #define print_backtrace()
-#endif
 #endif
 
 #else

--- a/src/main.cc
+++ b/src/main.cc
@@ -228,7 +228,7 @@ int main(int argc, char **argv, char **envp)
                 
             case 'D':
                 
-#ifndef DEBUG_LOG_ENABLED
+#ifndef TOMBDEBUG
                 print_copyright();
                 printf("ERROR: MediaTomb wasn't compiled with debug output, but was run with -D/--debug.\n");
                 exit(EXIT_FAILURE);


### PR DESCRIPTION
- The -D/--debug command line option flipped its sense when
  TOMBDEBUG was defined. Now it behaves consistently.
- Removed the redundant DEBUG_LOG_ENABLED (replaced with TOMBDEBUG)