### PR TITLE
Re-support SIGHUP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ mediatomb.spec
 mediatomb-service-optware
 .idea
 cmake-build-debug
+*.orig
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+Makefile
+mediatomb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,13 @@ if(NOT HOST_OS)
                 "mediatomb was unable to deterimine the host OS. Please report this. Value of CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 endif()
 
+# X86 Check
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(i386)|(x86)|(X86)|(amd64)|(AMD64)")
+    set (X86 TRUE)
+else ()
+    set (X86 FALSE)
+endif ()
+
 if (SOLARIS)
     add_definitions(-DSOLARIS)
     # we need these specially called out as not in packages [OmniOS/joyent]
@@ -348,6 +355,12 @@ add_definitions(-DPACKAGE_DATADIR="${CMAKE_INSTALL_PREFIX}/share/mediatomb")
 
 add_definitions(-DCOMPILE_INFO="")
 add_definitions(-DEXTERNAL_TRANSCODING)
+
+# this got removed/ignored in CmakeLists transition
+# story so far is that this can be enabled on X86
+if (X86)
+    add_definitions(-DENABLE_SIGHUP)
+endif(X86)
 
 if (WITH_LOGGING OR WITH_DEBUG_LOGGING)
     add_definitions(-DLOG_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,12 +356,6 @@ add_definitions(-DPACKAGE_DATADIR="${CMAKE_INSTALL_PREFIX}/share/mediatomb")
 add_definitions(-DCOMPILE_INFO="")
 add_definitions(-DEXTERNAL_TRANSCODING)
 
-# this got removed/ignored in CmakeLists transition
-# story so far is that this can be enabled on X86
-if (X86)
-    add_definitions(-DENABLE_SIGHUP)
-endif(X86)
-
 if (WITH_LOGGING OR WITH_DEBUG_LOGGING)
     add_definitions(-DLOG_ENABLED)
 endif()

--- a/src/main.cc
+++ b/src/main.cc
@@ -740,13 +740,9 @@ void signal_handler(int signum)
     }
     else if (signum == SIGHUP)
     {
-#if defined(ENABLE_SIGHUP)
         restart_flag = 1;
         if (timer != nil)
             timer->signal();
-#else
-        log_warning("SIGHUP handling was disabled during compilation.\n");
-#endif
     }
 
     return;

--- a/src/main.cc
+++ b/src/main.cc
@@ -97,23 +97,23 @@ int main(int argc, char **argv, char **envp)
     int      opt_index = 0;
     int      o;
     static struct option long_options[] = {
-        {"ip", 1, 0, 'i'},          // 0
-        {"interface", 1, 0, 'e'},   // 1
-        {"port", 1, 0, 'p'},        // 2
-        {"config", 1, 0, 'c'},      // 3
-        {"home", 1, 0, 'm'},        // 4
-        {"cfgdir", 1, 0, 'f'},      // 5
-        {"user", 1, 0, 'u'},        // 6
-        {"group", 1, 0, 'g'},       // 7
-        {"daemon", 0, 0, 'd'},      // 8
-        {"pidfile", 1, 0, 'P'},     // 9
-        {"add", 1, 0, 'a'},         // 10
-        {"logfile", 1, 0, 'l'},     // 11
-        {"debug", 0, 0, 'D'},       // 12
-        {"compile-info", 0, 0, 0},  // 13
-        {"version", 0, 0, 0},       // 14
-        {"help", 0, 0, 'h'},        // 15
-        {0, 0, 0, 0}                
+        {(char *)"ip", 1, 0, 'i'},          // 0
+        {(char *)"interface", 1, 0, 'e'},   // 1
+        {(char *)"port", 1, 0, 'p'},        // 2
+        {(char *)"config", 1, 0, 'c'},      // 3
+        {(char *)"home", 1, 0, 'm'},        // 4
+        {(char *)"cfgdir", 1, 0, 'f'},      // 5
+        {(char *)"user", 1, 0, 'u'},        // 6
+        {(char *)"group", 1, 0, 'g'},       // 7
+        {(char *)"daemon", 0, 0, 'd'},      // 8
+        {(char *)"pidfile", 1, 0, 'P'},     // 9
+        {(char *)"add", 1, 0, 'a'},         // 10
+        {(char *)"logfile", 1, 0, 'l'},     // 11
+        {(char *)"debug", 0, 0, 'D'},       // 12
+        {(char *)"compile-info", 0, 0, 0},  // 13
+        {(char *)"version", 0, 0, 0},       // 14
+        {(char *)"help", 0, 0, 'h'},        // 15
+        {(char *)0, 0, 0, 0}                
     };
 
     String config_file;


### PR DESCRIPTION
This fell on the floor during the cmake migration
autodetecting [an attempt] to enable on X86 platforms. 
The real intent is not to detect X86, but to detect
and not enable on ARM, according to old README
...also a .gitignore tweak you can ignore, if you insist