### PR TITLE
re-silence "event is ok" info message

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -316,7 +316,7 @@ int Server::upnp_callback(Upnp_EventType eventtype, const void* event, void* coo
         return UPNP_E_BAD_REQUEST;
     }
 
-    log_info("event is ok\n");
+    //log_info("event is ok\n");
     // get device wide mutex (have to figure out what the hell that is)
     AutoLock lock(mutex);
 


### PR DESCRIPTION
Super simple - e4c0f5c769ed313fbf5fe95c983ee7251fb7b6eb left the un-commented "event is ok" message, which will crap up one's log rather quickly.  
I assume that was an unintended side-effect.
Just re-commenting it back out.