### PR TITLE
Add includes for solaris for USHRT_MAX and signal handling

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -36,6 +36,12 @@
 
 #include <getopt.h>
 
+// first do no harm; may be safe for others
+#ifdef SOLARIS
+#include <signal.h>
+#include <iso/limits_iso.h>
+#endif
+
 #include "common.h"
 #include "server.h"
 #include "content_manager.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -36,9 +36,8 @@
 
 #include <getopt.h>
 
-// first do no harm; may be safe for others
+#include <csignal>
 #ifdef SOLARIS
-#include <signal.h>
 #include <iso/limits_iso.h>
 #endif
 


### PR DESCRIPTION
Recent changes broke my build; some things not defined by default.
Particularly because the ISO defines aren't necessarily standard, i put them in an ifdef block.
If you feel they're safe for everyone, by all means pull them out.