### PR TITLE
Avoid warning by explict casting

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -251,7 +251,7 @@ For more information visit " DESC_MANUFACTURER_URL "\n\n");
                 fwrite(pid.c_str(), sizeof(char), pid.length(), pid_fd);
             fclose(pid_fd);
 
-            if (size < pid.length()) {
+            if (static_cast<int>(size) < pid.length()) {
                 log_error("Error when writing pid file %s : %s\n",
                           pid_file.c_str(), strerror(errno));
             }


### PR DESCRIPTION
...,but note that this all reveals that perhaps zmm::String should be replaced with std::string, and
anyway, why is zmm::String.length() not a size_t?